### PR TITLE
Updated html docs sections for clarity

### DIFF
--- a/app/views/comboboxes/_5_html.html.erb
+++ b/app/views/comboboxes/_5_html.html.erb
@@ -21,13 +21,16 @@
 
     <%= paragraph do %>
       As you saw from the YouTube example, <%= mono(":render_in") %> is also supported
-      in async comboboxes. Simply include the rendering options in the Turbo Stream template.
+      in async comboboxes. Simply include the rendering options in the Turbo Stream template. 
+      Please note that since the options are requested as a turbo_stream response, you will 
+      need to ensure that you are using a <%= mono(".turbo_stream.erb") %> partial. If you 
+      want to use an html partial, simply add <%= mono("formats: [:html]") %> to the <%= mono(":render_in") %> options.
     <% end %>
 
     <%=
       highlight_erb(%(
         &lt;%= async_combobox_options @page.records,
-              render_in: { partial: "states/state" },
+              render_in: { partial: "states/state", formats: [:html] },
               next_page: @page.last? ? nil : @page.next_param %&gt;
       ), "In views/states/index.turbo_stream.erb")
     %>


### PR DESCRIPTION
The existing docs section on HTML comboboxes dealing with using partials with async boxes was not entirely clear. I have updated the docs to specify that, when using async comboboxes, the partial needs to be a turbo_streams partial, or the `:render_in` function needs to use the option `formats: [:html]`.

See: https://github.com/josefarias/hotwire_combobox/discussions/116